### PR TITLE
Improve output streams

### DIFF
--- a/__tests__/Output/OutputStream.test.ts
+++ b/__tests__/Output/OutputStream.test.ts
@@ -54,31 +54,4 @@ describe("OutputStream", () => {
 
     });
 
-    describe("close", () => {
-
-        it("should close the stream", async () => {
-            // Arrange
-            const output = new OutputStream();
-            const text = "foo bar baz lorem";
-            const input = new InputStream(text.repeat(3), { highWaterMark: text.length });
-
-            // Act
-            output.on("data", () => {
-                output.close();
-            });
-
-            input.pipe(output);
-
-            // Assert
-            await (new Promise((resolve) => {
-                output.on("finish", () => {
-                    expect(output.toString()).toEqual(text);
-                    expect(output.toBuffer().toString()).toEqual(text);
-                    resolve();
-                });
-            }));
-        });
-
-    });
-
 });

--- a/__tests__/Process/Process.test.ts
+++ b/__tests__/Process/Process.test.ts
@@ -317,7 +317,7 @@ describe("Process", () => {
 
             // Act
             setTimeout(() => {
-                runningProcess.stop();
+                runningProcess.stop("SIGINT");
             }, 2500);
 
             // Assert

--- a/__tests__/Process/Process.test.ts
+++ b/__tests__/Process/Process.test.ts
@@ -302,7 +302,7 @@ describe("Process", () => {
 
     describe("stop", () => {
 
-        it("should kill the underlaying process", async () => {
+        it("should kill the underlying process", async () => {
             // Arrange
             const runningProcess = new Process(["node", path.join(__dirname, "test-process.js")]);
             await runningProcess.start();

--- a/__tests__/Process/Process.test.ts
+++ b/__tests__/Process/Process.test.ts
@@ -7,12 +7,12 @@
  * File that was distributed with this source code.
  */
 
+import * as path from "path";
 import { LogicException } from "../../src/Exception/LogicException";
 import { ProcessFailedException } from "../../src/Exception/ProcessFailedException";
 import { RuntimeException } from "../../src/Exception/RuntimeException";
+import { OutputStream } from "../../src/Output/OutputStream";
 import { Process } from "../../src/Process/Process";
-import * as path from "path";
-import { OutputStream } from "../../src";
 
 describe("Process", () => {
 
@@ -296,6 +296,35 @@ describe("Process", () => {
                 expect(difference).toBeLessThan(20);
                 expect(difference).toBeGreaterThan(-20);
             }
+        });
+
+    });
+
+    describe("stop", () => {
+
+        it("should kill the underlaying process", async () => {
+            // Arrange
+            const runningProcess = new Process(["node", path.join(__dirname, "test-process.js")]);
+            await runningProcess.start();
+            const output = new OutputStream();
+            const stdout = runningProcess.getStdout();
+
+            const messages: string[] = [];
+
+            output.on("data", (chunk: Buffer) => {
+                messages.push(chunk.toString());
+            });
+
+            // Act
+            setTimeout(() => {
+                runningProcess.stop();
+            }, 2500);
+
+            // Assert
+            stdout.pipe(output);
+            await runningProcess.wait();
+
+            expect(messages.length).toBe(2);
         });
 
     });

--- a/__tests__/Process/Process.test.ts
+++ b/__tests__/Process/Process.test.ts
@@ -11,6 +11,8 @@ import { LogicException } from "../../src/Exception/LogicException";
 import { ProcessFailedException } from "../../src/Exception/ProcessFailedException";
 import { RuntimeException } from "../../src/Exception/RuntimeException";
 import { Process } from "../../src/Process/Process";
+import * as path from "path";
+import { OutputStream } from "../../src";
 
 describe("Process", () => {
 
@@ -248,6 +250,52 @@ describe("Process", () => {
 
             // Assert
             expect(actual.getOutput()).toBe("foo");
+        });
+
+    });
+
+    describe("getStdout", () => {
+
+        it("should pipe continuously", async () => {
+            // Arrange
+            const runningProcess = new Process(["node", path.join(__dirname, "test-process.js")]);
+            await runningProcess.start();
+            const output = new OutputStream();
+            const stdout = runningProcess.getStdout();
+
+            interface Message {
+                timestamp: number;
+
+                output: {
+                    index: number;
+                    timestamp: number;
+                }
+            }
+
+            const messages: Message[] = [];
+
+            output.on("data", (chunk: Buffer) => {
+                const now = new Date();
+                const timestamp = now.getTime();
+
+                messages.push({
+                    timestamp,
+                    output: JSON.parse(chunk.toString()),
+                });
+            });
+
+            // Act
+            stdout.pipe(output);
+            await runningProcess.wait();
+
+            // Assert
+            expect(messages.length).toBe(3);
+
+            for (const message of messages) {
+                const difference = message.output.timestamp - message.timestamp;
+                expect(difference).toBeLessThan(20);
+                expect(difference).toBeGreaterThan(-20);
+            }
         });
 
     });

--- a/__tests__/Process/Process.test.ts
+++ b/__tests__/Process/Process.test.ts
@@ -293,8 +293,8 @@ describe("Process", () => {
 
             for (const message of messages) {
                 const difference = message.output.timestamp - message.timestamp;
-                expect(difference).toBeLessThan(20);
-                expect(difference).toBeGreaterThan(-20);
+                expect(difference).toBeLessThan(50);
+                expect(difference).toBeGreaterThan(-50);
             }
         });
 

--- a/__tests__/Process/test-process.js
+++ b/__tests__/Process/test-process.js
@@ -2,23 +2,22 @@ function write(text) {
     process.stdout.write(text);
 }
 
-const startIndex = 1000;
 const times = 3;
-const limit = startIndex + times - 1;
-
-let index = startIndex;
+const interval = 1000;
+let index = 1;
 
 function next() {
-    if (current === limit) {
+    if (index === times + 1) {
         return;
     }
 
     const current = index++;
 
     setTimeout(function () {
-        write(JSON.stringify({ index: current, timestamp: (new Date()).getTime() }));
+        const timestamp = (new Date()).getTime();
+        write(JSON.stringify({ index: current, timestamp }));
         next();
-    }, current);
+    }, interval);
 }
 
 next();

--- a/__tests__/Process/test-process.js
+++ b/__tests__/Process/test-process.js
@@ -1,0 +1,24 @@
+function write(text) {
+    process.stdout.write(text);
+}
+
+const startIndex = 1000;
+const times = 3;
+const limit = startIndex + times - 1;
+
+let index = startIndex;
+
+function next() {
+    const current = index++;
+
+    if (current - 1 === limit) {
+        return;
+    }
+
+    setTimeout(function () {
+        write(JSON.stringify({ index: current, timestamp: (new Date()).getTime() }));
+        next();
+    }, current);
+}
+
+next();

--- a/__tests__/Process/test-process.js
+++ b/__tests__/Process/test-process.js
@@ -9,11 +9,11 @@ const limit = startIndex + times - 1;
 let index = startIndex;
 
 function next() {
-    const current = index++;
-
-    if (current - 1 === limit) {
+    if (current === limit) {
         return;
     }
+
+    const current = index++;
 
     setTimeout(function () {
         write(JSON.stringify({ index: current, timestamp: (new Date()).getTime() }));

--- a/src/Output/OutputStream.ts
+++ b/src/Output/OutputStream.ts
@@ -7,22 +7,22 @@
  * File that was distributed with this source code.
  */
 
-import { Writable, WritableOptions } from "stream";
+import { Transform, TransformOptions } from "stream";
 
-export class OutputStream extends Writable {
+export class OutputStream extends Transform {
 
     protected contents = Buffer.from("");
 
     protected closed: boolean = false;
 
-    public constructor(options?: WritableOptions) {
+    public constructor(options?: TransformOptions) {
         super(options);
     }
 
-    public _write(chunk: Buffer, encoding: string, callback: () => void) {
+    public _transform(chunk: Buffer, encoding: string, callback: () => void) {
         if (!this.closed) {
             this.contents = Buffer.concat([this.contents, chunk]);
-            this.emit("data", chunk);
+            this.push(chunk);
         }
         callback();
     }

--- a/src/Output/OutputStream.ts
+++ b/src/Output/OutputStream.ts
@@ -13,17 +13,13 @@ export class OutputStream extends Transform {
 
     protected contents = Buffer.from("");
 
-    protected closed: boolean = false;
-
     public constructor(options?: TransformOptions) {
         super(options);
     }
 
     public _transform(chunk: Buffer, encoding: string, callback: () => void) {
-        if (!this.closed) {
-            this.contents = Buffer.concat([this.contents, chunk]);
-            this.push(chunk);
-        }
+        this.contents = Buffer.concat([this.contents, chunk]);
+        this.push(chunk);
         callback();
     }
 
@@ -33,18 +29,6 @@ export class OutputStream extends Transform {
 
     public toString(): string {
         return this.contents.toString();
-    }
-
-    public isClosed(): boolean {
-        return this.closed;
-    }
-
-    public close(): this {
-        this.closed = true;
-        this.emit("close");
-        this.emit("finish");
-
-        return this;
     }
 
 }

--- a/src/Process/Process.ts
+++ b/src/Process/Process.ts
@@ -139,6 +139,9 @@ export class Process {
                 } else {
                     this.exitCode = null !== signal ? 1 : 0;
                 }
+
+                this.status = ProcessStatus.TERMINATED;
+                resolve(this.exitCode);
             });
 
             this.process.on("close", (code: number | null) => {
@@ -280,7 +283,7 @@ export class Process {
      *
      * @param {string} signal
      */
-    public stop(signal: NodeJS.Signals = "SIGTERM"): void {
+    public stop(signal: NodeJS.Signals = "SIGINT"): void {
         this.status = ProcessStatus.TERMINATED;
         this.process.kill(signal);
     }

--- a/src/Process/Process.ts
+++ b/src/Process/Process.ts
@@ -283,8 +283,6 @@ export class Process {
     public stop(signal: NodeJS.Signals = "SIGTERM"): void {
         this.status = ProcessStatus.TERMINATED;
         this.process.kill(signal);
-        this.stdout.close();
-        this.stderr.close();
     }
 
     public getStdout(): OutputStream {

--- a/src/Process/Process.ts
+++ b/src/Process/Process.ts
@@ -287,6 +287,14 @@ export class Process {
         this.stderr.close();
     }
 
+    public getStdout(): OutputStream {
+        return this.stdout;
+    }
+
+    public getStderr(): OutputStream {
+        return this.stderr;
+    }
+
     private async getShell(): Promise<string> {
         const command = "win32" === os.platform() ? "where" : "which";
 


### PR DESCRIPTION
In order to pipe the output from *stdout* or *stderr* directly into other targets the `OutputStream` have to be a `Duplex` to be readable and writable. The `Transform` offers the simplest solution.

I also removed the `close` method and tests for the `OutputStream`, let NodeJS internally handle all this stuff.