### PR TITLE
Add process environment

### DIFF
--- a/__tests__/Process/Process.test.ts
+++ b/__tests__/Process/Process.test.ts
@@ -345,4 +345,34 @@ describe("Process", () => {
 
     });
 
+    describe("environment", () => {
+
+        test("app_env is not set", async () => {
+            // Arrange
+            const process = new Process(["node", "-e", "process.stdout.write(process.env.APP_FOO||'undefined');"]);
+
+            // Act
+            const actual = await process.mustRun();
+
+            // Assert
+            expect(actual.getOutput()).toBe("undefined");
+        });
+
+        it("should set environment vars", async () => {
+            // Arrange
+            const process = new Process(["node", "-e", "process.stdout.write(process.env.APP_FOO);"], {
+                environment: {
+                    "app_foo": "bar",
+                },
+            });
+
+            // Act
+            const actual = await process.mustRun();
+
+            // Assert
+            expect(actual.getOutput()).toBe("bar");
+        });
+
+    });
+
 });

--- a/__tests__/Process/Process.test.ts
+++ b/__tests__/Process/Process.test.ts
@@ -347,7 +347,7 @@ describe("Process", () => {
 
     describe("environment", () => {
 
-        test("app_env is not set", async () => {
+        test("APP_END should be unset", async () => {
             // Arrange
             const process = new Process(["node", "-e", "process.stdout.write(process.env.APP_FOO||'undefined');"]);
 

--- a/__tests__/Process/Process.test.ts
+++ b/__tests__/Process/Process.test.ts
@@ -360,9 +360,9 @@ describe("Process", () => {
 
         it("should set environment vars", async () => {
             // Arrange
-            const process = new Process(["node", "-e", "process.stdout.write(process.env.APP_FOO);"], {
+            const process = new Process(["node", "-e", "process.stdout.write(process.env.APP_FOO||'undefined');"], {
                 environment: {
-                    "app_foo": "bar",
+                    "APP_FOO": "bar",
                 },
             });
 

--- a/__tests__/Process/Process.test.ts
+++ b/__tests__/Process/Process.test.ts
@@ -347,7 +347,7 @@ describe("Process", () => {
 
     describe("environment", () => {
 
-        test("APP_END should be unset", async () => {
+        test("APP_FOO should be unset", async () => {
             // Arrange
             const process = new Process(["node", "-e", "process.stdout.write(process.env.APP_FOO||'undefined');"]);
 

--- a/src/Process/Process.ts
+++ b/src/Process/Process.ts
@@ -46,6 +46,7 @@ export class Process {
         this.options = {
             directory: process.cwd(),
             input: null,
+            environment: null,
             ...options,
         };
 
@@ -100,6 +101,10 @@ export class Process {
             stdio: "pipe",
             shell,
         };
+
+        if (null !== this.options.environment) {
+            options.env = this.options.environment;
+        }
 
         this.process = childProcess.spawn(this.command, this.args, options);
         this.status = ProcessStatus.STARTED;

--- a/src/Process/ProcessOptions.ts
+++ b/src/Process/ProcessOptions.ts
@@ -18,4 +18,9 @@ export interface ProcessOptions {
      * The stdin for the process
      */
     input: string | null;
+
+    /**
+     * The environment for the process
+     */
+    environment: NodeJS.ProcessEnv | null;
 }


### PR DESCRIPTION
Sometimes you want to modify the environment in which the command will run, but you don't want to  pollute the host environment. With this implementation you can set environment variables for the child process.